### PR TITLE
Minor fix to committee name

### DIFF
--- a/pages/proyectos-de-ley/index.js
+++ b/pages/proyectos-de-ley/index.js
@@ -295,7 +295,7 @@ export default function Bills() {
                   )}
                 billId={id}
                 billTitle={title}
-                committeeName={last_committee ?? void 0}
+                committeeName={last_committee?.committee_name ?? void 0}
                 publicationDate={presentation_date}
                 status={last_status ?? ''}
                 lastUpdate={last(tracking).date}


### PR DESCRIPTION
Avoid error when using filter, according to structure in API data.

closes #124 