### PR TITLE
Add grafana embedded dashboard

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,5 +19,7 @@ module.exports = {
       id: 2879782,
       version: 6,
     },
+    grafanaDashboard:
+      'https://grafana.data.congreso.openpolitica.com/d/23_rPc87z/exploracion-asistencias-y-votaciones-plenos-2021-2026?orgId=1&kiosk&theme=light',
   },
 };

--- a/pages/data-lab/index.js
+++ b/pages/data-lab/index.js
@@ -14,18 +14,20 @@ export default function DataLab() {
       <Breadcrumb routes={routes} />
 
       <CUI.Flex w="full" align="stretch" flexDirection="column" mt="1rem">
-        <CUI.AspectRatio ratio={9 / 16} display={{ base: 'flex', md: 'none' }}>
-          <iframe
-            title="Exploración de datos de asistencias y votaciones"
-            src={process.env.grafanaDashboard}
-          />
-        </CUI.AspectRatio>
-        <CUI.AspectRatio ratio={16 / 9} display={{ base: 'none', md: 'block' }}>
-          <iframe
-            title="Exploración de datos de asistencias y votaciones"
-            src={process.env.grafanaDashboard}
-          />
-        </CUI.AspectRatio>
+        <CUI.Box
+          as="iframe"
+          title="Exploración de datos de asistencias y votaciones"
+          src={process.env.grafanaDashboard}
+          height={{
+            base: '500vw',
+            sm: '470vw',
+            md: '250vh',
+            lg: '200vh',
+            xl: '150vh',
+            '2xl': '120vh',
+          }}
+          allowFullScreen
+        />
       </CUI.Flex>
     </SidebarLayout>
   );

--- a/pages/data-lab/index.js
+++ b/pages/data-lab/index.js
@@ -1,3 +1,4 @@
+import * as CUI from '@chakra-ui/react';
 import React from 'react';
 import Breadcrumb from 'components/Breadcrumb';
 import SidebarLayout from 'components/layout/SidebarLayout';
@@ -11,6 +12,21 @@ export default function DataLab() {
   return (
     <SidebarLayout>
       <Breadcrumb routes={routes} />
+
+      <CUI.Flex w="full" align="stretch" flexDirection="column" mt="1rem">
+        <CUI.AspectRatio ratio={9 / 16} display={{ base: 'flex', md: 'none' }}>
+          <iframe
+            title="Exploración de datos de asistencias y votaciones"
+            src={process.env.grafanaDashboard}
+          />
+        </CUI.AspectRatio>
+        <CUI.AspectRatio ratio={16 / 9} display={{ base: 'none', md: 'block' }}>
+          <iframe
+            title="Exploración de datos de asistencias y votaciones"
+            src={process.env.grafanaDashboard}
+          />
+        </CUI.AspectRatio>
+      </CUI.Flex>
     </SidebarLayout>
   );
 }


### PR DESCRIPTION
Add grafana link to data lab page. Check at `/data-lab` 

The embedded dashboard is the allowed dashboard in grafana for anonymous users:
https://grafana.data.congreso.openpolitica.com/d/23_rPc87z/exploracion-asistencias-y-votaciones-plenos-2021-2026?orgId=1&kiosk&theme=light 

closes #137 